### PR TITLE
URL Cleanup

### DIFF
--- a/superzip/data/deps.sh
+++ b/superzip/data/deps.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 wget http://notebook.gaslampmedia.com/wp-content/uploads/2013/08/zip_codes_states.csv
-wget http://www.aei.org/files/2012/02/16/-revisedmurrayfile_111952895138.xls
+wget https://www.aei.org/files/2012/02/16/-revisedmurrayfile_111952895138.xls


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://notebook.gaslampmedia.com/wp-content/uploads/2013/08/zip_codes_states.csv (200) could not be migrated:  
   ([https](https://notebook.gaslampmedia.com/wp-content/uploads/2013/08/zip_codes_states.csv) result SSLHandshakeException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.aei.org/files/2012/02/16/-revisedmurrayfile_111952895138.xls migrated to:  
  https://www.aei.org/files/2012/02/16/-revisedmurrayfile_111952895138.xls ([https](https://www.aei.org/files/2012/02/16/-revisedmurrayfile_111952895138.xls) result 302).