### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [Superzip Shiny Gallery example](https://github.com/rstudio/shiny-examples/tree/master/063-superzip-example), slightly modified to run on Cloud Foundry (CF).  You can find a [live version of the app running on CF here](https://superzip.apps.pcfdemo.net/).
 
-Please refer to the [Shiny Apps on CF section](http://pivotalsoftware.github.io/gp-r/#shiny_cf) of the Pivotal & R Practitioner's Guide for guidance on how the original code from RStudio was slightly modified to run on CF.  In line with what is described in the guide, only the following files were modified/added from the original RStudio code to make this happen:
+Please refer to the [Shiny Apps on CF section](https://pivotalsoftware.github.io/gp-r/#shiny_cf) of the Pivotal & R Practitioner's Guide for guidance on how the original code from RStudio was slightly modified to run on CF.  In line with what is described in the guide, only the following files were modified/added from the original RStudio code to make this happen:
 
 * Modified: [ui.R](https://github.com/pivotalsoftware/superzip/blob/master/superzip/UI.R), [server.R](https://github.com/pivotalsoftware/superzip/blob/master/superzip/server.R)
 * Added: [init.r](https://github.com/pivotalsoftware/superzip/blob/master/init.r), [startscript.R](https://github.com/pivotalsoftware/superzip/blob/master/startscript.R), [manifest.yml](https://github.com/pivotalsoftware/superzip/blob/master/manifest.yml), [r.yml](https://github.com/pivotalsoftware/superzip/blob/master/r.yml)

--- a/superzip/DESCRIPTION
+++ b/superzip/DESCRIPTION
@@ -2,6 +2,6 @@ Title: SuperZip example
 License: MIT
 DisplayMode: Normal
 Author: Joe Cheng <joe@rstudio.com>
-AuthorUrl: http://www.rstudio.com/
+AuthorUrl: https://www.rstudio.com/
 Type: Shiny
 Tags: leaflet selectize datatables absolutepanel

--- a/superzip/README.md
+++ b/superzip/README.md
@@ -1,6 +1,6 @@
 # SuperZIP demo
 
-See a version of it live at http://shiny.rstudio.com/gallery/superzip-example.html
+See a version of it live at https://shiny.rstudio.com/gallery/superzip-example.html
 
 You can run this demo with:
 ```
@@ -10,4 +10,4 @@ devtools::install_github("rstudio/leaflet")
 shiny::runGitHub("rstudio/shiny-examples", subdir="063-superzip-example")
 ```
 
-Data compiled for _Coming Apart: The State of White America, 1960–2010_ by Charles Murray (Crown Forum, 2012). This app was inspired by the Washington Post's interactive feature _[Washington: A world apart](http://www.washingtonpost.com/sf/local/2013/11/09/washington-a-world-apart/)_.
+Data compiled for _Coming Apart: The State of White America, 1960–2010_ by Charles Murray (Crown Forum, 2012). This app was inspired by the Washington Post's interactive feature _[Washington: A world apart](https://www.washingtonpost.com/sf/local/2013/11/09/washington-a-world-apart/)_.

--- a/superzip/server.R
+++ b/superzip/server.R
@@ -23,7 +23,7 @@ shinyServer(function(input, output, session) {
     leaflet() %>%
       addTiles(
         urlTemplate = "//{s}.tiles.mapbox.com/v3/jcheng.map-5ebohr46/{z}/{x}/{y}.png",
-        attribution = 'Maps by <a href="http://www.mapbox.com/">Mapbox</a>'
+        attribution = 'Maps by <a href="https://www.mapbox.com/">Mapbox</a>'
       ) %>%
       setView(lng = -93.85, lat = 37.45, zoom = 4)
   })


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://pivotalsoftware.github.io/gp-r/ with 1 occurrences migrated to:  
  https://pivotalsoftware.github.io/gp-r/ ([https](https://pivotalsoftware.github.io/gp-r/) result 200).
* http://shiny.rstudio.com/gallery/superzip-example.html with 1 occurrences migrated to:  
  https://shiny.rstudio.com/gallery/superzip-example.html ([https](https://shiny.rstudio.com/gallery/superzip-example.html) result 200).
* http://www.mapbox.com/ with 1 occurrences migrated to:  
  https://www.mapbox.com/ ([https](https://www.mapbox.com/) result 200).
* http://www.rstudio.com/ with 1 occurrences migrated to:  
  https://www.rstudio.com/ ([https](https://www.rstudio.com/) result 200).
* http://www.washingtonpost.com/sf/local/2013/11/09/washington-a-world-apart/ with 1 occurrences migrated to:  
  https://www.washingtonpost.com/sf/local/2013/11/09/washington-a-world-apart/ ([https](https://www.washingtonpost.com/sf/local/2013/11/09/washington-a-world-apart/) result 302).